### PR TITLE
Bug fix for WorkflowRunCanNotBeCancelled error message not getting propagated 

### DIFF
--- a/templates/cancel-runs-by-tracking-id.json
+++ b/templates/cancel-runs-by-tracking-id.json
@@ -45,7 +45,7 @@
                       "from": "@body('Filter_for_errors')[0]['outputs']",
                       "select": {
                         "action": "@item()['name']",
-                        "error": "@item()['outputs']['body']['error']['message']",
+                        "error": "@coalesce(item()['outputs']['body']?['message'],item()['outputs']['body']?['error']['message'])",
                         "statusCode": "@item()['outputs']['statusCode']"
                       }
                     },

--- a/templates/cancel-runs-by-tracking-id.json
+++ b/templates/cancel-runs-by-tracking-id.json
@@ -45,7 +45,7 @@
                       "from": "@body('Filter_for_errors')[0]['outputs']",
                       "select": {
                         "action": "@item()['name']",
-                        "error": "@item()['outputs']['body']['message']",
+                        "error": "@item()['outputs']['body']['error']['message']",
                         "statusCode": "@item()['outputs']['statusCode']"
                       }
                     },


### PR DESCRIPTION
'message' is not a direct child of 'body' but a child of 'error' node.

"body": {
        "error": {
          "code": "WorkflowRunCanNotBeCancelled",
          "message": "The workflow 'gateway_scheduler' run '08586388553662904605665179615CU14' with state 'Succeeded' could not be canceled, because it is not active."
        }
      }