### PR TITLE
Add new Azure Security Center templates to logic apps

### DIFF
--- a/templates/asc-alert-send-notification-email.json
+++ b/templates/asc-alert-send-notification-email.json
@@ -8,57 +8,57 @@
         },
         "categoryNames": [
             "general",
-			"security"
+            "security"
         ],
         "description": "Send an email notification with the alert details when a threat is detected",
         "displayName": "Get a notification email when Security Center detects a threat",
         "definition": {
-		  "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
-          "actions": {
-            "Send_an_email": {
-              "type": "ApiConnection",
-              "inputs": {
-                "host": {
-                  "connection": {
-                    "name": "@parameters('$connections')['office365']['connectionId']"
-                  }
-                },
-                "method": "post",
-                "body": {
-                  "To": null,
-                  "Subject": "Azure Security Center has discovered a potential security threat in your environment",
-                  "Body": "Azure Security Center has discovered a potential security threat in your environment - Alert details below:\n\nAlert name: @{triggerBody()?['AlertDisplayName']}\n\nDescription: @{triggerBody()?['Description']}\n\nDetection time: @{triggerBody()?['TimeGenerated']}\n\nAttacked resource: @{triggerBody()?['CompromisedEntity']}\n\nDetected by: @{triggerBody()?['VendorName']}\n\nAlert ID: @{triggerBody()?['SystemAlertId']}",
-                  "Importance": "High"
-				},
-                "path": "/Mail"
-              },
-              "runAfter": {}
-            }
-          },
-          "parameters": {
-            "$connections": {
-              "defaultValue": {},
-              "type": "Object"
-            }
-          },
-          "triggers": {
-            "When_an_Azure_Security_Center_Alert_is_created": {
-              "type": "ApiConnectionWebhook",
-              "inputs": {
-                "host": {
-                  "connection": {
-                    "name": "@parameters('$connections')['ascalert']['connectionId']"
-                  }
-                },
-                "body": {
-                  "callback_url": "@{listCallbackUrl()}"
-                },
-                "path": "/Microsoft.Security/Alert/subscribe"
-              }
-            }
-          },
-          "contentVersion": "1.0.0.0",
-          "outputs": {}
+            "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+            "actions": {
+                "Send_an_email": {
+                    "type": "ApiConnection",
+                    "inputs": {
+                        "host": {
+                            "connection": {
+                                "name": "@parameters('$connections')['office365']['connectionId']"
+                            }
+                        },
+                        "method": "post",
+                        "body": {
+                            "To": null,
+                            "Subject": "Azure Security Center has discovered a potential security threat in your environment",
+                            "Body": "Azure Security Center has discovered a potential security threat in your environment - Alert details below:\n\nAlert name: @{triggerBody()?['AlertDisplayName']}\n\nDescription: @{triggerBody()?['Description']}\n\nDetection time: @{triggerBody()?['TimeGenerated']}\n\nAttacked resource: @{triggerBody()?['CompromisedEntity']}\n\nDetected by: @{triggerBody()?['VendorName']}\n\nAlert ID: @{triggerBody()?['SystemAlertId']}",
+                            "Importance": "High"
+                        },
+                        "path": "/Mail"
+                    },
+                    "runAfter": {}
+                }
+            },
+            "parameters": {
+                "$connections": {
+                    "defaultValue": {},
+                    "type": "Object"
+                }
+            },
+            "triggers": {
+                "When_an_Azure_Security_Center_Alert_is_created": {
+                    "type": "ApiConnectionWebhook",
+                    "inputs": {
+                        "host": {
+                            "connection": {
+                                "name": "@parameters('$connections')['ascalert']['connectionId']"
+                            }
+                        },
+                        "body": {
+                            "callback_url": "@{listCallbackUrl()}"
+                        },
+                        "path": "/Microsoft.Security/Alert/subscribe"
+                    }
+                }
+            },
+            "contentVersion": "1.0.0.0",
+            "outputs": {}
         },
         "connectionReferences": {
             "office365": {
@@ -79,13 +79,13 @@
             }
         },
         "apiSummaries": [
-			{
+            {
                 "type": "apiconnection",
                 "displayName": "Azure Security Center Alert",
                 "iconUri": "https://connectoricons-prod.azureedge.net/ascalert/icon_1.0.1221.1620.png",
                 "brandColor": "#99c419"
             },
-			{
+            {
                 "type": "apiconnection",
                 "displayName": "${Resources.OUTLOOK}",
                 "iconUri": "https://az818438.vo.msecnd.net/icons/outlook.png",

--- a/templates/asc-alert-send-notification-email.json
+++ b/templates/asc-alert-send-notification-email.json
@@ -27,10 +27,9 @@
                 "body": {
                   "To": null,
                   "Subject": "Azure Security Center has discovered a potential security threat in your environment",
-                  "Body": "Azure Security Center has discovered a potential security threat in your environment - Alert details below:\r\n\r\nAlert name: @{triggerBody()?['AlertDisplayName']}\r\n\nDescription: @{triggerBody()?['Description']}\r\n\r\nDetection time: @{triggerBody()?['TimeGenerated']}\r\n\r\nAttacked resource: @{triggerBody()?['CompromisedEntity']}\r\n\r\nDetected by: @{triggerBody()?['VendorName']}\r\n\r\nAlert ID: @{triggerBody()?['SystemAlertId']}",
-                  "Importance": "High",
-                  "IsHtml": true
-                },
+                  "Body": "Azure Security Center has discovered a potential security threat in your environment - Alert details below:\nAlert name: @{triggerBody()?['AlertDisplayName']}\nDescription: @{triggerBody()?['Description']}\nDetection time: @{triggerBody()?['TimeGenerated']}\nAttacked resource: @{triggerBody()?['CompromisedEntity']}\nDetected by: @{triggerBody()?['VendorName']}\nAlert ID: @{triggerBody()?['SystemAlertId']}",
+                  "Importance": "High"
+				},
                 "path": "/Mail"
               },
               "runAfter": {}

--- a/templates/asc-alert-send-notification-email.json
+++ b/templates/asc-alert-send-notification-email.json
@@ -7,7 +7,8 @@
             "displayName": "Microsoft"
         },
         "categoryNames": [
-            "general"
+            "general",
+			"security"
         ],
         "description": "Send an email notification with the alert details when a threat is detected",
         "displayName": "Get a notification email when Security Center detects a threat",
@@ -19,7 +20,7 @@
               "inputs": {
                 "host": {
                   "connection": {
-                    "name": "@parameters('$connections')['office365_1']['connectionId']"
+                    "name": "@parameters('$connections')['office365']['connectionId']"
                   }
                 },
                 "method": "post",
@@ -61,12 +62,12 @@
           "outputs": {}
         },
         "connectionReferences": {
-            "office365_1": {
+            "office365": {
                 "connection": {
                     "id": ""
                 },
                 "api": {
-                    "id": "/subscriptions/{0}/providers/Microsoft.Web/locations/{1}/managedApis/office365_1"
+                    "id": "/subscriptions/{0}/providers/Microsoft.Web/locations/{1}/managedApis/office365"
                 }
             },
             "ascalert": {
@@ -81,7 +82,7 @@
         "apiSummaries": [
 			{
                 "type": "apiconnection",
-                "displayName": "${Resources.ASCAlert}",
+                "displayName": "Azure Security Center Alert",
                 "iconUri": "https://connectoricons-prod.azureedge.net/ascalert/icon_1.0.1221.1620.png",
                 "brandColor": "#99c419"
             },

--- a/templates/asc-alert-send-notification-email.json
+++ b/templates/asc-alert-send-notification-email.json
@@ -27,7 +27,7 @@
                 "body": {
                   "To": null,
                   "Subject": "Azure Security Center has discovered a potential security threat in your environment",
-                  "Body": "Azure Security Center has discovered a potential security threat in your environment - Alert details below:\nAlert name: @{triggerBody()?['AlertDisplayName']}\nDescription: @{triggerBody()?['Description']}\nDetection time: @{triggerBody()?['TimeGenerated']}\nAttacked resource: @{triggerBody()?['CompromisedEntity']}\nDetected by: @{triggerBody()?['VendorName']}\nAlert ID: @{triggerBody()?['SystemAlertId']}",
+                  "Body": "Azure Security Center has discovered a potential security threat in your environment - Alert details below:\n\nAlert name: @{triggerBody()?['AlertDisplayName']}\n\nDescription: @{triggerBody()?['Description']}\n\nDetection time: @{triggerBody()?['TimeGenerated']}\n\nAttacked resource: @{triggerBody()?['CompromisedEntity']}\n\nDetected by: @{triggerBody()?['VendorName']}\n\nAlert ID: @{triggerBody()?['SystemAlertId']}",
                   "Importance": "High"
 				},
                 "path": "/Mail"

--- a/templates/asc-alert-send-notification-email.json
+++ b/templates/asc-alert-send-notification-email.json
@@ -1,0 +1,99 @@
+{
+    "id": "/providers/Microsoft.Logic/galleries/public/templates/d27feb15-dc1d-4068-93c5-d9dca32806cd",
+    "type": "Microsoft.Logic/galleries/templates",
+    "name": "d27feb15-dc1d-4068-93c5-d9dca32806cd",
+    "properties": {
+        "author": {
+            "displayName": "Microsoft"
+        },
+        "categoryNames": [
+            "general"
+        ],
+        "description": "Send an email notification with the alert details when a threat is detected",
+        "displayName": "Get a notification email when Security Center detects a threat",
+        "definition": {
+		  "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "actions": {
+            "Send_an_email": {
+              "type": "ApiConnection",
+              "inputs": {
+                "host": {
+                  "connection": {
+                    "name": "@parameters('$connections')['office365_1']['connectionId']"
+                  }
+                },
+                "method": "post",
+                "body": {
+                  "To": null,
+                  "Subject": "Azure Security Center has discovered a potential security threat in your environment",
+                  "Body": "Azure Security Center has discovered a potential security threat in your environment - Alert details below:\n\nAlert name: @{triggerBody()?['AlertDisplayName']}\n\nDescription: @{triggerBody()?['Description']}\n\nDetection time: @{triggerBody()?['TimeGenerated']}\n\nAttacked resource: @{triggerBody()?['CompromisedEntity']}\n\nDetected by: @{triggerBody()?['VendorName']}\n\nAlert ID: @{triggerBody()?['SystemAlertId']}",
+                  "Importance": "High",
+                  "IsHtml": true
+                },
+                "path": "/Mail"
+              },
+              "runAfter": {}
+            }
+          },
+          "parameters": {
+            "$connections": {
+              "defaultValue": {},
+              "type": "Object"
+            }
+          },
+          "triggers": {
+            "When_an_Azure_Security_Center_Alert_is_created": {
+              "type": "ApiConnectionWebhook",
+              "inputs": {
+                "host": {
+                  "connection": {
+                    "name": "@parameters('$connections')['ascalert']['connectionId']"
+                  }
+                },
+                "body": {
+                  "callback_url": "@{listCallbackUrl()}"
+                },
+                "path": "/Microsoft.Security/Alert/subscribe"
+              }
+            }
+          },
+          "contentVersion": "1.0.0.0",
+          "outputs": {}
+        },
+        "connectionReferences": {
+            "office365_1": {
+                "connection": {
+                    "id": ""
+                },
+                "api": {
+                    "id": "/subscriptions/{0}/providers/Microsoft.Web/locations/{1}/managedApis/office365_1"
+                }
+            },
+            "ascalert": {
+                "connection": {
+                    "id": ""
+                },
+                "api": {
+                    "id": "/subscriptions/{0}/providers/Microsoft.Web/locations/{1}/managedApis/ascalert"
+                }
+            }
+        },
+        "apiSummaries": [
+			{
+                "type": "apiconnection",
+                "displayName": "${Resources.ASCAlert}",
+                "iconUri": "https://connectoricons-prod.azureedge.net/ascalert/icon_1.0.1221.1620.png",
+                "brandColor": "#99c419"
+            },
+			{
+                "type": "apiconnection",
+                "displayName": "${Resources.OUTLOOK}",
+                "iconUri": "https://az818438.vo.msecnd.net/icons/outlook.png",
+                "brandColor": "#0072c6"
+            }
+        ],
+        "changedTime": "2000-07-11T00:00:00.000Z",
+        "createdTime": "2000-07-11T00:00:00.000Z",
+        "popularity": 99
+    }
+}

--- a/templates/asc-alert-send-notification-email.json
+++ b/templates/asc-alert-send-notification-email.json
@@ -92,8 +92,8 @@
                 "brandColor": "#0072c6"
             }
         ],
-        "changedTime": "2000-07-11T00:00:00.000Z",
-        "createdTime": "2000-07-11T00:00:00.000Z",
+        "changedTime": "2019-07-11T00:00:00.000Z",
+        "createdTime": "2019-07-11T00:00:00.000Z",
         "popularity": 99
     }
 }

--- a/templates/asc-alert-send-notification-email.json
+++ b/templates/asc-alert-send-notification-email.json
@@ -27,7 +27,7 @@
                 "body": {
                   "To": null,
                   "Subject": "Azure Security Center has discovered a potential security threat in your environment",
-                  "Body": "Azure Security Center has discovered a potential security threat in your environment - Alert details below:\n\nAlert name: @{triggerBody()?['AlertDisplayName']}\n\nDescription: @{triggerBody()?['Description']}\n\nDetection time: @{triggerBody()?['TimeGenerated']}\n\nAttacked resource: @{triggerBody()?['CompromisedEntity']}\n\nDetected by: @{triggerBody()?['VendorName']}\n\nAlert ID: @{triggerBody()?['SystemAlertId']}",
+                  "Body": "Azure Security Center has discovered a potential security threat in your environment - Alert details below:\r\n\r\nAlert name: @{triggerBody()?['AlertDisplayName']}\r\n\nDescription: @{triggerBody()?['Description']}\r\n\r\nDetection time: @{triggerBody()?['TimeGenerated']}\r\n\r\nAttacked resource: @{triggerBody()?['CompromisedEntity']}\r\n\r\nDetected by: @{triggerBody()?['VendorName']}\r\n\r\nAlert ID: @{triggerBody()?['SystemAlertId']}",
                   "Importance": "High",
                   "IsHtml": true
                 },

--- a/templates/asc-recommendation-send-notification-email.json
+++ b/templates/asc-recommendation-send-notification-email.json
@@ -27,7 +27,7 @@
                 "body": {
                   "To": null,
                   "Subject": "Azure Security Center has discovered a potential security vulnerability in your environment",
-                  "Body": "Azure Security Center has discovered a potential security vulnerability in your environment - Recommendation details below:\n\nRecommendation name: @{triggerBody()?['properties']?['displayName']}\n\n@{triggerBody()?['properties']?['source']}\n\nResource ID: @{triggerBody()?['properties']?['resourceDetails']?['id']}\n"
+                  "Body": "Azure Security Center has discovered a potential security vulnerability in your environment - Recommendation details below:\n\nRecommendation name: @{triggerBody()?['properties']?['displayName']}\n\nResource ID: @{triggerBody()?['properties']?['resourceDetails']?['id']}\n"
                 },
                 "path": "/Mail"
               },

--- a/templates/asc-recommendation-send-notification-email.json
+++ b/templates/asc-recommendation-send-notification-email.json
@@ -1,0 +1,98 @@
+{
+    "id": "/providers/Microsoft.Logic/galleries/public/templates/7835cb8c-ee78-49d6-bfa7-0840c61e96b3",
+    "type": "Microsoft.Logic/galleries/templates",
+    "name": "7835cb8c-ee78-49d6-bfa7-0840c61e96b3",
+    "properties": {
+        "author": {
+            "displayName": "Microsoft"
+        },
+        "categoryNames": [
+            "general",
+			"security"
+        ],
+        "description": "Send an email notification with the recommendation details when a resource is not securely configured",
+        "displayName": "Get a notification email when Security Center creates a recommendation",
+		"definition": {
+          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "actions": {
+            "Send_a_notification_email": {
+              "type": "ApiConnection",
+              "inputs": {
+                "host": {
+                  "connection": {
+                    "name": "@parameters('$connections')['office365']['connectionId']"
+                  }
+                },
+                "method": "post",
+                "body": {
+                  "To": null,
+                  "Subject": "Azure Security Center has discovered a potential security vulnerability in your environment",
+                  "Body": "Azure Security Center has discovered a potential security vulnerability in your environment - Recommendation details below:\n\nRecommendation name: @{triggerBody()?['properties.displayName']}\n\n@{triggerBody()?['name']}\n\nResource ID: @{triggerBody()?['properties']?['resourceDetails']?['id']}\n"
+                },
+                "path": "/Mail"
+              },
+              "runAfter": {}
+            }
+          },
+          "parameters": {
+            "$connections": {
+              "defaultValue": {},
+              "type": "Object"
+            }
+          },
+          "triggers": {
+            "When_an_Azure_Security_Center_Assessment_is_created": {
+              "type": "ApiConnectionWebhook",
+              "inputs": {
+                "host": {
+                  "connection": {
+                    "name": "@parameters('$connections')['ascassessment']['connectionId']"
+                  }
+                },
+                "body": {
+                  "callback_url": "@{listCallbackUrl()}"
+                },
+                "path": "/Microsoft.Security/Assessment/subscribe"
+              }
+            }
+          },
+          "contentVersion": "1.0.0.0",
+          "outputs": {}
+        },
+        "connectionReferences": {
+			"office365": {
+				"connection": {
+					"id": ""
+				},
+				"api": {
+					"id": "/subscriptions/{0}/providers/Microsoft.Web/locations/{1}/managedApis/office365"
+                }
+            },
+            "ascassessment": {
+                "connection": {
+                    "id": ""
+                },
+                "api": {
+                    "id": "/subscriptions/{0}/providers/Microsoft.Web/locations/{1}/managedApis/ascassessment"
+                }
+            }
+        },
+        "apiSummaries": [
+            {
+                "type": "apiconnection",
+                "displayName": "Azure Security Center Recommendation",
+                "iconUri": "https://connectoricons-df.azureedge.net/ascassessment/icon_1.0.1221.1620.png",
+                "brandColor": "#99c419"
+            },
+			{
+                "type": "apiconnection",
+                "displayName": "${Resources.OUTLOOK}",
+                "iconUri": "https://az818438.vo.msecnd.net/icons/outlook.png",
+                "brandColor": "#0072c6"
+            }
+        ],
+        "changedTime": "2019-07-15T00:00:00.000Z",
+        "createdTime": "2019-07-15T00:00:00.000Z",
+        "popularity": 99
+    }
+}

--- a/templates/asc-recommendation-send-notification-email.json
+++ b/templates/asc-recommendation-send-notification-email.json
@@ -27,7 +27,7 @@
                 "body": {
                   "To": null,
                   "Subject": "Azure Security Center has discovered a potential security vulnerability in your environment",
-                  "Body": "Azure Security Center has discovered a potential security vulnerability in your environment - Recommendation details below:\n\nRecommendation name: @{triggerBody()?['properties.displayName']}\n\n@{triggerBody()?['properties.source']}\n\nResource ID: @{triggerBody()?['properties']?['resourceDetails']?['id']}\n"
+                  "Body": "Azure Security Center has discovered a potential security vulnerability in your environment - Recommendation details below:\n\nRecommendation name: @{triggerBody()?['properties']?['displayName']}\n\n@{triggerBody()?['properties']?['source']}\n\nResource ID: @{triggerBody()?['properties']?['resourceDetails']?['id']}\n"
                 },
                 "path": "/Mail"
               },

--- a/templates/asc-recommendation-send-notification-email.json
+++ b/templates/asc-recommendation-send-notification-email.json
@@ -8,64 +8,64 @@
         },
         "categoryNames": [
             "general",
-			"security"
+            "security"
         ],
         "description": "Send an email notification with the recommendation details when a resource is not securely configured",
         "displayName": "Get a notification email when Security Center creates a recommendation",
-		"definition": {
-          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
-          "actions": {
-            "Send_a_notification_email": {
-              "type": "ApiConnection",
-              "inputs": {
-                "host": {
-                  "connection": {
-                    "name": "@parameters('$connections')['office365']['connectionId']"
-                  }
-                },
-                "method": "post",
-                "body": {
-                  "To": null,
-                  "Subject": "Azure Security Center has discovered a potential security vulnerability in your environment",
-                  "Body": "Azure Security Center has discovered a potential security vulnerability in your environment - Recommendation details below:\n\nRecommendation name: @{triggerBody()?['properties']?['displayName']}\n\nResource ID: @{triggerBody()?['properties']?['resourceDetails']?['id']}\n"
-                },
-                "path": "/Mail"
-              },
-              "runAfter": {}
-            }
-          },
-          "parameters": {
-            "$connections": {
-              "defaultValue": {},
-              "type": "Object"
-            }
-          },
-          "triggers": {
-            "When_an_Azure_Security_Center_Assessment_is_created": {
-              "type": "ApiConnectionWebhook",
-              "inputs": {
-                "host": {
-                  "connection": {
-                    "name": "@parameters('$connections')['ascassessment']['connectionId']"
-                  }
-                },
-                "body": {
-                  "callback_url": "@{listCallbackUrl()}"
-                },
-                "path": "/Microsoft.Security/Assessment/subscribe"
-              }
-            }
-          },
-          "contentVersion": "1.0.0.0",
-          "outputs": {}
+        "definition": {
+            "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+            "actions": {
+                "Send_a_notification_email": {
+                    "type": "ApiConnection",
+                    "inputs": {
+                        "host": {
+                            "connection": {
+                                "name": "@parameters('$connections')['office365']['connectionId']"
+                            }
+                        },
+                        "method": "post",
+                        "body": {
+                            "To": null,
+                            "Subject": "Azure Security Center has discovered a potential security vulnerability in your environment",
+                            "Body": "Azure Security Center has discovered a potential security vulnerability in your environment - Recommendation details below:\n\nRecommendation name: @{triggerBody()?['properties']?['displayName']}\n\nResource ID: @{triggerBody()?['properties']?['resourceDetails']?['id']}\n"
+                        },
+                        "path": "/Mail"
+                    },
+                    "runAfter": {}
+                }
+            },
+            "parameters": {
+                "$connections": {
+                    "defaultValue": {},
+                    "type": "Object"
+                }
+            },
+            "triggers": {
+                "When_an_Azure_Security_Center_Assessment_is_created": {
+                    "type": "ApiConnectionWebhook",
+                    "inputs": {
+                        "host": {
+                            "connection": {
+                                "name": "@parameters('$connections')['ascassessment']['connectionId']"
+                            }
+                        },
+                        "body": {
+                            "callback_url": "@{listCallbackUrl()}"
+                        },
+                        "path": "/Microsoft.Security/Assessment/subscribe"
+                    }
+                }
+            },
+            "contentVersion": "1.0.0.0",
+            "outputs": {}
         },
         "connectionReferences": {
-			"office365": {
-				"connection": {
-					"id": ""
-				},
-				"api": {
-					"id": "/subscriptions/{0}/providers/Microsoft.Web/locations/{1}/managedApis/office365"
+            "office365": {
+                "connection": {
+                    "id": ""
+                },
+                "api": {
+                    "id": "/subscriptions/{0}/providers/Microsoft.Web/locations/{1}/managedApis/office365"
                 }
             },
             "ascassessment": {
@@ -84,7 +84,7 @@
                 "iconUri": "https://connectoricons-df.azureedge.net/ascassessment/icon_1.0.1221.1620.png",
                 "brandColor": "#99c419"
             },
-			{
+            {
                 "type": "apiconnection",
                 "displayName": "${Resources.OUTLOOK}",
                 "iconUri": "https://az818438.vo.msecnd.net/icons/outlook.png",

--- a/templates/asc-recommendation-send-notification-email.json
+++ b/templates/asc-recommendation-send-notification-email.json
@@ -27,7 +27,7 @@
                 "body": {
                   "To": null,
                   "Subject": "Azure Security Center has discovered a potential security vulnerability in your environment",
-                  "Body": "Azure Security Center has discovered a potential security vulnerability in your environment - Recommendation details below:\n\nRecommendation name: @{triggerBody()?['properties.displayName']}\n\n@{triggerBody()?['name']}\n\nResource ID: @{triggerBody()?['properties']?['resourceDetails']?['id']}\n"
+                  "Body": "Azure Security Center has discovered a potential security vulnerability in your environment - Recommendation details below:\n\nRecommendation name: @{triggerBody()?['properties.displayName']}\n\n@{triggerBody()?['properties.source']}\n\nResource ID: @{triggerBody()?['properties']?['resourceDetails']?['id']}\n"
                 },
                 "path": "/Mail"
               },

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,7 @@
 [
     "as2-response.json",
     "asc-alert-send-notification-email.json",
+    "asc-recommendation-send-notification-email.json",
     "asc-post-message-to-slack.json",
     "asc-post-message-to-teams-and-send-notification-email.json",
     "asc-send-notification-email.json",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,9 +1,9 @@
 [
     "as2-response.json",
     "asc-alert-send-notification-email.json",
-    "asc-recommendation-send-notification-email.json",
     "asc-post-message-to-slack.json",
     "asc-post-message-to-teams-and-send-notification-email.json",
+    "asc-recommendation-send-notification-email.json",
     "asc-send-notification-email.json",
     "azure-monitor-metric-alert-handler.json",
     "Azure-Blob-Auto-Expiration.json",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 [
     "as2-response.json",
-	"asc-alert-send-notification-email.json",
+    "asc-alert-send-notification-email.json",
     "asc-post-message-to-slack.json",
     "asc-post-message-to-teams-and-send-notification-email.json",
     "asc-send-notification-email.json",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,6 @@
 [
     "as2-response.json",
+	"asc-alert-send-notification-email.json",
     "asc-post-message-to-slack.json",
     "asc-post-message-to-teams-and-send-notification-email.json",
     "asc-send-notification-email.json",


### PR DESCRIPTION
Add 2 new templates for logic apps:
1) For ASC Alert:
Trigger: Azure Security Center Alert connector
Action: Send an email

2) For ASC Recommendation:
Trigger: Azure Security Center Assessment connector
Action: Send an email

The connectors I use are preview connectors