### PR TITLE
Fixing bug with until running for the max timeout

### DIFF
--- a/templates/service-bus-sessions.json
+++ b/templates/service-bus-sessions.json
@@ -431,7 +431,7 @@
                 }
               },
               "description": "This block keeps asking for more messages in the session for 1 hour or as long as it finds messages in the queue for the session, whichever comes first. To hold longer, change the 'Timeout' property of this Until block",
-              "expression": "@not(equals(variables('isDone'), true))",
+              "expression": "@equals(variables('isDone'), true)",
               "limit": {
                 "timeout": "PT1H"
               },


### PR DESCRIPTION
The until action was running until it hit the 1 hour timeout. When walking through the logic and variables I believe running until the isDone variable is true was the expected result. I tested this change a few times in my environment and it is now working as expected.