### PR TITLE
azure/CLI failing due old az cli version

### DIFF
--- a/github-sample/.github/workflows/IaC_deploy.yml
+++ b/github-sample/.github/workflows/IaC_deploy.yml
@@ -55,7 +55,6 @@ jobs:
     - name: Update Logic App Connections 
       uses: azure/CLI@v1
       with:
-        azcliversion: 2.0.72
         inlineScript: |
           az functionapp config appsettings set --name ${{ steps.ladeploy.outputs.LAname }} --resource-group  ${{ secrets.RG_LA }} --settings "BLOB_CONNECTION_RUNTIMEURL=${{ steps.msdemoconn.outputs.blobendpointurl }}"
           az functionapp config appsettings set --name ${{ steps.ladeploy.outputs.LAname }} --resource-group  ${{ secrets.RG_LA }} --settings "WORKFLOWS_RESOURCE_GROUP_NAME=${{ secrets.RG_CON }}"


### PR DESCRIPTION
azure/CLI@v1 is configured to use a very old version of Azure CLI, due to which az functionapp config commands were failing. Remove explicit az cli dependency, letting the action choose az cli version of the agent. 

Error reported due to old az cli version:

ERROR: Please run 'az account set' to select active account. Error: Error: az cli script failed.
cleaning up container...
MICROSOFT_AZURE_CLI_1665621746187_CONTAINER