### PR TITLE
For 'Standard' AppServicePlan 'WEBSITE_CONTENTSHARE' settings aren't supported.

### DIFF
--- a/github-sample/ARM/la-template.json
+++ b/github-sample/ARM/la-template.json
@@ -122,11 +122,7 @@
               {
                 "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
                 "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('storageName'),';AccountKey=',concat(listKeys(concat(resourceGroup().id,'/providers/Microsoft.Storage/storageAccounts/', parameters('storageName')),'2019-06-01').keys[0].value),';EndpointSuffix=core.windows.net')]"
-              },
-              {
-                "name": "WEBSITE_CONTENTSHARE",
-                "value": "[parameters('logicAppName')]"
-              },
+              },              
               {
                 "name": "WEBSITE_NODE_DEFAULT_VERSION",
                 "value": "~12"


### PR DESCRIPTION
Using 'Standard' App service Plan for App Deployment. "Microsoft.Web/serverfarms"

"sku": {
          "name": "WS1",
          "tier": "WorkflowStandard"
        },
The WEBSITE_CONTENTSHARE settings aren't supported.

https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code?tabs=json#create-a-function-app-2

