### PR TITLE
'Standard' App service plan, won't support WEBSITE_CONTENTSHARE settings.

### DIFF
--- a/github-sample/ARM/la-template.json
+++ b/github-sample/ARM/la-template.json
@@ -122,11 +122,7 @@
               {
                 "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
                 "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('storageName'),';AccountKey=',concat(listKeys(concat(resourceGroup().id,'/providers/Microsoft.Storage/storageAccounts/', parameters('storageName')),'2019-06-01').keys[0].value),';EndpointSuffix=core.windows.net')]"
-              },
-              {
-                "name": "WEBSITE_CONTENTSHARE",
-                "value": "[parameters('logicAppName')]"
-              },
+              },              
               {
                 "name": "WEBSITE_NODE_DEFAULT_VERSION",
                 "value": "~12"


### PR DESCRIPTION
While planning to deploy Logic App (Standard) with 'Standard/ Dedicated' App Service plan.  Then WEBSITE_CONTENTSHARE settings won't support.

1.) Error while I try to deploy the logicApp with standard App service plan (la.template.json):
 
[ Error: ERROR.• *** "status"Failed", "error": *** "code": "DeploynentFaiIed" , "message" : "At least one resource deploymentoperation failed. Please list deployment operations for details. Pleasedetails . " , "details ." • *** "code": "BadRequest" , "message":pa rameter ÅESSITE_CONTENTSHARE has an invalid ualue.\", \ "Target \\ " message\": \ "The parameter WEBSITE _ CONTENT SHARE has an invalid value. \ "ErrorEntity\"•see for usage, \ "Message\"***\r\n\ " ExtendedCode\ :V'Parameters\" :\ " messageTempIate\" •. \ "The parameterWEBSITE_CONTENTSHARE has an invalid value. \has an invalid value.\ "Code V':]

2.) Error Fix:

Under AppSetting property just remove the below settings: 

{
                "name": "WEBSITE_CONTENTSHARE",
                "value": "[parameters('logicAppName')]"
              },

Ref., link: 
https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code?tabs=json#create-a-function-app-2 https://learn.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code?tabs=json#deploy-on-app-service-plan

AB#16118791