### PR TITLE
Use "azure/CLI@v1" to Swap parameter files Not "azure/powershell@v1"

### DIFF
--- a/github-sample/.github/workflows/logicapp_deploy.yml
+++ b/github-sample/.github/workflows/logicapp_deploy.yml
@@ -77,9 +77,7 @@ jobs:
 
     - name: Swap parameter files 
       id: params
-      uses: azure/powershell@v1
+      uses: azure/CLI@v1
       with:
         inlineScript: |
           az functionapp deploy --resource-group ${{ secrets.RG_LA }} --name ${{ env.LA_NAME }} --src-path  logic/azure.parameters.json --type static --target-path parameters.json
-        azPSVersion: latest
-


### PR DESCRIPTION
In Swap parameter files, 

1.) In logicApp_deploy.yml, using the PowerShell version to execute the CLI az commands won't work.

- name: Swap parameter files 
      id: params
      uses: azure/powershell@v1
      with:
        inlineScript: |
          az functionapp deploy --resource-group ${{ secrets.RG_LA }} --name ${{ env.LA_NAME }} --src-path  logic/azure.parameters.json --type static --target-path parameters.json 
  azPSVersion: latest


2.) Required changes: 
Remove "uses: azure/powershell@v1" and use CLI version "uses: azure/CLI@v1" and remove the "azPSVersion", we need CLI latest version not PowerShell latest version.

 - name: Swap parameter files  
    id: params 
    uses: azure/CLI@v1 
    with:
       inlineScript: | 
           az functionapp deploy --resource-group ${{ secrets.RG_LA }} --name ${{ env.LA_NAME }} --src-path  logic/azure.parameters.json --type static --target-path parameters.json 