### PR TITLE
Various fixes on logic apps standard Azure DevOps sample

### DIFF
--- a/azure-devops-sample/.pipelines/classic/templates/template-iac-logicapp.yml
+++ b/azure-devops-sample/.pipelines/classic/templates/template-iac-logicapp.yml
@@ -70,7 +70,8 @@ jobs:
 
         - task: AzureCLI@2
           inputs:
-            azureSubscription: 'devconnection2'
+            # TODO: Fill in with the name of your Azure service connection
+            azureSubscription: ''
             scriptType: 'bash'
             scriptLocation: 'inlineScript'
             inlineScript: |

--- a/azure-devops-sample/.pipelines/classic/variables/pipeline-vars.yml
+++ b/azure-devops-sample/.pipelines/classic/variables/pipeline-vars.yml
@@ -9,7 +9,7 @@ variables:
   resourceGroupLocation: 'westus'
   resourceGroupName: 'rg-wus-$(projectName)-$(suffix)'
 
-  # Storage - make sure this is unique!
+  # Storage - make sure this is unique and that the projectName you choose above is short enough, due to storage account name length restriction: https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#storage-account-name
   storageName: 'sa$(projectName)$(suffix)'
   appServicePlanName: 'asp$(projectName)$(suffix)'
 

--- a/azure-devops-sample/.pipelines/container/variables/pipeline-vars.yml
+++ b/azure-devops-sample/.pipelines/container/variables/pipeline-vars.yml
@@ -16,7 +16,7 @@ variables:
   acrName: 'acrwus$(projectName)$(suffix)'
   acrSkuName: 'Basic'
 
-  # Storage
+  # Storage - make sure this is unique and that the projectName you choose above is short enough, due to storage account name length restriction: https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#storage-account-name
   storageName: 'sa$(projectName)$(suffix)'
   appServicePlanName: 'asp$(projectName)$(suffix)'
 

--- a/azure-devops-sample/logic/EventProcessor/workflow.json
+++ b/azure-devops-sample/logic/EventProcessor/workflow.json
@@ -27,7 +27,7 @@
                     "headers": {
                         "ReadFileMetadataFromServer": true
                     },
-                    "path": "/v2/datasets/@{encodeURIComponent(encodeURIComponent('sacb34ucffd7en6'))}/files",
+                    "path": "/v2/datasets/@{encodeURIComponent(encodeURIComponent(parameters('storage_account_name')))}/files",
                     "queries": {
                         "folderPath": "/blobs",
                         "name": "@{utcNow()}",

--- a/azure-devops-sample/logic/EventProcessor/workflow.json
+++ b/azure-devops-sample/logic/EventProcessor/workflow.json
@@ -27,7 +27,7 @@
                     "headers": {
                         "ReadFileMetadataFromServer": true
                     },
-                    "path": "/v2/datasets/@{encodeURIComponent(encodeURIComponent(parameters('storage_account_name')))}/files",
+                    "path": "/v2/datasets/@{encodeURIComponent(parameters('storage_account_name'))}/files",
                     "queries": {
                         "folderPath": "/blobs",
                         "name": "@{utcNow()}",

--- a/azure-devops-sample/logic/azure.parameters.json
+++ b/azure-devops-sample/logic/azure.parameters.json
@@ -4,5 +4,9 @@
         "value": {
             "type": "ManagedServiceIdentity"
         }
+    },
+    "storage_account_name": {
+      "type": "String",
+      "value": "@appsetting('storage-account-name')"
     }
 }

--- a/azure-devops-sample/logic/parameters.json
+++ b/azure-devops-sample/logic/parameters.json
@@ -6,6 +6,9 @@
             "scheme": "Key",
             "parameter": "@appsetting('azureblob-connectionKey')"
         }
+    },
+    "storage_account_name": {
+      "type": "String",
+      "value": "@appsetting('storage-account-name')"
     }
-
 }


### PR DESCRIPTION
- Inside template-iac-logicapp.yml change the azureSubscription property from “devconnection2” on Line 73 to the name of the connection that you have created and filled out also in other TODO comments
- Inside the file pipeline-vars.yml, make sure that the projectName you choose is short enough, due to [storage account name length restriction](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#storage-account-name)
- Inside the file /logic/EventProcessor/workflow.json, in the “path” property of the json file, the storage account name (in the encodeURIComponent('sacb34ucffd7en6')) should be changed to be your own storage account name (or even better you should change it to be a parameter – as the same should have been in the sample as well)

