### PR TITLE
Fix: Retrieve correct service principal ID.

### DIFF
--- a/arc-enabled-logic-app-sample/env/deploy.sh
+++ b/arc-enabled-logic-app-sample/env/deploy.sh
@@ -6,7 +6,7 @@ echo 'Create Service Principal...'
 # create service principal
 export SP_INFO=$(az ad sp create-for-rbac --skip-assignment -n $SP_NAME)
 export CLIENT_ID=$(echo $SP_INFO | jq .appId  -r)
-export OBJECT_ID=$(az ad sp show --id $CLIENT_ID --query 'objectId' -o tsv)
+export OBJECT_ID=$(az ad app show --id $CLIENT_ID --query 'id' -o tsv)
 export CLIENT_SECRET=$(echo $SP_INFO | jq .password  -r)
 export TENANT_ID=$(echo $SP_INFO | jq .tenant  -r)
 


### PR DESCRIPTION
The command to retrieve the service principal ID is not correct (anymore): It doesn't retrieve the ID. 

This pull request fixes the command so that the service principal ID will be retrieved correctly. 